### PR TITLE
feat: add api docker file; add pgadmin and swagger to docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ build/
 
 ### Mac Environment ###
 .DS_Store
+
+### Docker Data ###
+.docker-data/

--- a/api/DockerFile
+++ b/api/DockerFile
@@ -1,0 +1,35 @@
+FROM openjdk:17-jdk-alpine
+
+RUN apk add --no-cache curl tar bash procps
+
+ARG MAVEN_VERSION=3.9.1
+
+ARG USER_HOME_DIR="/root"
+
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && echo "Downlaoding maven" \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  \
+  && echo "Unziping maven" \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  \
+  && echo "Cleaning and setting links" \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY ./src ./src
+COPY ./pom.xml ./pom.xml
+
+RUN mvn install 
+RUN mvn package spring-boot:repackage
+
+RUN cp ./target/captionlive-0.0.1-SNAPSHOT.jar ./backend.jar
+ENTRYPOINT ["java", "-jar", "backend.jar"]
+
+EXPOSE 8080
+

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,51 @@
+# Backend
+Web server for CaptionLive!.
+
+## Swagger
+Graphical User Interface to test APIs provided by the server.
+
+### To manipulate the DB with Swagger UI
+Enter the following URL into the browser
+```
+http://localhost:8080/swagger-ui/index.html#/
+```
+
+## Spring Backend
+
+### Running the Backend in the command line (Mac)
+Go to the backend directory
+```
+cd CaptionLive/api
+```
+
+Install the Maven
+```
+brew install maven
+```
+
+Install dependencies
+```
+mvn install 
+```
+
+Compile
+```
+mvn package spring-boot:repackage
+```
+
+Start the application
+```
+java -jar target/captionlive-0.0.1-SNAPSHOT.jar
+```
+
+### Running the Backend via Docker
+```
+docker build -t cl_api -f DockerFile .
+docker run -p 8080:8080 -td cl_api
+```
+
+### Running the Backend via Docker (No Cache)
+```
+docker build --no-cache -t cl_api -f DockerFile .
+docker run -p 8080:8080 -td cl_api
+```

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/main/java/com/aguri/captionlive/config/OpenAPIInfo.java
+++ b/api/src/main/java/com/aguri/captionlive/config/OpenAPIInfo.java
@@ -1,0 +1,29 @@
+package com.aguri.captionlive.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAPIInfo {
+
+    @Bean
+    public OpenAPI customOpenAPI(
+            @Value("${apiTitle}") String apiTitle,
+            @Value("${apiDescription}") String apiDescription,
+            @Value("${apiVersion}") String apiVersion
+
+    ) {
+        return new OpenAPI()
+                .components(new Components())
+                .info(new Info()
+                        .title(apiTitle)
+                        .description(apiDescription)
+                        .version(apiVersion)
+                );
+    }
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -3,7 +3,13 @@ spring:
     url: jdbc:postgresql://localhost:5432/postgres
     username: postgres
     password: 114514
+  
   jpa:
     hibernate:
       ddl-auto: create
     show-sql: true
+
+# Swagger UI Description
+apiTitle: "CaptionLive! API"
+apiDescription: "A Project Management System for Fansub Group, developed by Aguri's GRavity Lab. See the GitHub page for more information at https://github.com/lijiaxi2018/CaptionLive"
+apiVersion: "0.1"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -3,17 +3,33 @@ version: "3.7"
 services:
   db:
     image: postgres:14.7
+    volumes:
+      - "../docker-data/psql-data:/var/lib/postgresql/data"
     container_name: captionlive_db
     ports:
       - "5432:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=114514
+  
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    depends_on:
+      - db
+    volumes:
+      - "../docker-data/pga4-data:/var/lib/pgadmin"
+    ports:
+      - "80:80"
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=pgadmin4@pgadmin.org
+      - PGADMIN_DEFAULT_PASSWORD=admin
+    container_name: "captionlive_pgadmin"
 
   api:
-    image: cl_api
+    image: lijiaxi2018/cl_api
+    restart: unless-stopped
     depends_on:
       - db
     container_name: captionlive_api
     ports:
-      - "8081:8081"
+      - "8080:8080"


### PR DESCRIPTION
## Problem
- docker-compose file lacks important components
- No Dockerfile for api

## Approach
- Added PDAdmin component to the docker-compose file
- Added Swagger Open API component to the docker-compose file
- Added Dockerfile for api
- Added README for api
- Updated gitignore
