### PR TITLE
Bugfix/jpa enum

### DIFF
--- a/api/src/main/java/com/aguri/captionlive/model/Membership.java
+++ b/api/src/main/java/com/aguri/captionlive/model/Membership.java
@@ -34,8 +34,9 @@ public class Membership {
     private LocalDateTime createdTime;
 
     public enum Permission {
-        LEADER(1),
-        MEMBER(0);
+        MEMBER(0),
+        LEADER(1);
+
         private final int value;
 
         Permission(int value) {

--- a/api/src/main/java/com/aguri/captionlive/model/Task.java
+++ b/api/src/main/java/com/aguri/captionlive/model/Task.java
@@ -53,15 +53,15 @@ public class Task {
     public static final Workflow[] AUDIO_AND_VIDEO_DEFAULT_WORKFLOWS = new Workflow[]{Workflow.SOURCE, Workflow.F_CHECK, Workflow.RENDERING};
 
     public enum Workflow {
+        SOURCE(0),
         TIMELINE(1),
-        K_TIMELINE(3),
         S_TIMELINE(2),
+        K_TIMELINE(3),
         TRANSLATION(4),
         EFFECT(5),
+        CHECK(6),
         POLISHING(7),
         EMBEDDING(8),
-        CHECK(6),
-        SOURCE(0),
         F_CHECK(9),
         RENDERING(10);
 


### PR DESCRIPTION
## Problem
- For enum mappings in JPA, the default is to map in the order of the enum constants, not by value.