### PR TITLE
chore: api upgrade maven

### DIFF
--- a/api/DockerFile
+++ b/api/DockerFile
@@ -2,7 +2,7 @@ FROM openjdk:17-jdk-alpine
 
 RUN apk add --no-cache curl tar bash procps
 
-ARG MAVEN_VERSION=3.9.2
+ARG MAVEN_VERSION=3.9.3
 
 RUN mkdir -p /app/files
 WORKDIR /app


### PR DESCRIPTION
## Problem & Approach
- Updated Maven Version on DockerCompose to 3.9.3